### PR TITLE
Fix bug in ranef

### DIFF
--- a/R/pedigree.R
+++ b/R/pedigree.R
@@ -379,7 +379,7 @@ setMethod("ranef", signature(object = "pedigreemm"),
                   dm <- data.matrix(ans[[nm]])
                   cn <- colnames(dm)
                   rn <- rownames(dm)
-                  dm <- as.matrix(rf[[nm]] %*% dm)
+                  dm <- as.matrix(t(rf[[nm]]) %*% dm)
                   colnames(dm) <- cn
                   rownames(dm) <- rn
                   ans[[nm]] <- data.frame(dm, check.names = FALSE)


### PR DESCRIPTION
`relfac()` returns upper triangular right Cholesky factor $L^T$. However, to backtransform the random effects we need the left Cholesky factor $L$.